### PR TITLE
build: changed the max length of geometrygeojson in the database to 5000

### DIFF
--- a/SQL-script-history/Version_4-23.10.25.sql
+++ b/SQL-script-history/Version_4-23.10.25.sql
@@ -17,7 +17,7 @@ create table Obstacle
     ObstacleID      int           not null
         primary key,
     Heightmeter     int           null,
-    GeometryGeoJson varchar(100)  null,
+    GeometryGeoJson varchar(5000)  null,
     Name            varchar(100)  null,
     Description     varchar(1000) null,
     Illuminated     int           null,

--- a/db.sql
+++ b/db.sql
@@ -17,7 +17,7 @@ create table Obstacle
     ObstacleID      int           not null
         primary key,
     Heightmeter     int           null,
-    GeometryGeoJson varchar(100)  null,
+    GeometryGeoJson varchar(5000)  null,
     Name            varchar(100)  null,
     Description     varchar(1000) null,
     Illuminated     int           null,


### PR DESCRIPTION
This pull request makes a schema update to the `Obstacle` table by increasing the allowed length of the `GeometryGeoJson` column. This change is applied in both the main schema file and the versioned migration script to support storing larger GeoJSON geometry data.

Schema changes:

* Increased the size of the `GeometryGeoJson` column in the `Obstacle` table from `varchar(100)` to `varchar(5000)` in both `db.sql` and `SQL-script-history/Version_4-23.10.25.sql` to allow for larger geometry data.