### PR TITLE
fix: wrong sequence in db.sql, fixed

### DIFF
--- a/SQL-script-history/Version_9-12.11.25.sql
+++ b/SQL-script-history/Version_9-12.11.25.sql
@@ -26,38 +26,6 @@ create table Status
     StatusName varchar(100) null
 );
 
-create table Obstacle
-(
-    ObstacleID      varchar(300)  not null
-        primary key,
-    Heightmeter     int           not null,
-    GeometryGeoJson varchar(5000) null,
-    Name            varchar(100)  null,
-    Description     varchar(1000) null,
-    Illuminated     int default 0 not null,
-    Type            int           not null,
-    Status          int default 0 not null,
-    Marking         int default 0 not null,
-    CreationTime    datetime      null,
-    UpdatedTime     datetime      null,
-    UserId          varchar(255)  not null,
-    constraint ObstacleIlluminated_fk
-        foreign key (Illuminated) references Illuminated (Illuminated),
-    constraint ObstacleMarking_fk
-        foreign key (Marking) references Marking (Marking),
-    constraint ObstacleStatus_fk
-        foreign key (Status) references Status (Status),
-    constraint ObstacleType_fk
-        foreign key (Type) references ObstacleType (Type),
-    constraint Obstacle_UserId_fk
-        foreign key (UserId) references AspNetUserRoles (UserId)
-);
-
-
-
-
-
-
 create table test
 (
     test_column int null
@@ -91,7 +59,7 @@ create table if not EXISTS AspNetRoles
     NormalizedName  varchar(255),
     ConcurrencyStamp  varchar(255),
     CONSTRAINT U_ROLE_ID_PK PRIMARY KEY (Id)
-);
+    );
 
 create table if not EXISTS AspNetUsers
 (
@@ -111,7 +79,7 @@ create table if not EXISTS AspNetUsers
     LockoutEnabled bit not null,
     AccessFailedCount int not null,
     CONSTRAINT PK_AspNetUsers PRIMARY KEY (Id)
-);
+    );
 create table if not EXISTS AspNetUserTokens
 (
     UserId varchar(255) not null,
@@ -119,7 +87,7 @@ create table if not EXISTS AspNetUserTokens
     Name  varchar(255) not null,
     Value  varchar(255),
     CONSTRAINT PK_AspNetUserTokens PRIMARY KEY (UserId, LoginProvider)
-);
+    );
 
 create table if not EXISTS AspNetRoleClaims
 (
@@ -129,8 +97,8 @@ create table if not EXISTS AspNetRoleClaims
     RoleId  varchar(255),
     CONSTRAINT PK_AspNetRoleClaims PRIMARY KEY (Id),
     foreign key(RoleId)
-        references AspNetRoles(Id)
-);
+    references AspNetRoles(Id)
+    );
 
 create table if not EXISTS AspNetUserClaims
 (
@@ -140,8 +108,8 @@ create table if not EXISTS AspNetUserClaims
     UserId  varchar(255),
     CONSTRAINT PK_AspNetRoleClaims PRIMARY KEY (Id),
     foreign key(UserId)
-        references AspNetUsers(Id)
-);
+    references AspNetUsers(Id)
+    );
 
 create table if not EXISTS AspNetUserLogins
 (
@@ -151,8 +119,8 @@ create table if not EXISTS AspNetUserLogins
     UserId  varchar(255) not null,
     CONSTRAINT PK_AspNetUserLogins PRIMARY KEY (LoginProvider),
     foreign key(UserId)
-        references AspNetUsers(Id)
-);
+    references AspNetUsers(Id)
+    );
 
 create table if not EXISTS AspNetUserRoles
 (
@@ -160,9 +128,36 @@ create table if not EXISTS AspNetUserRoles
     RoleId varchar(255) not null,
     CONSTRAINT PK_AspNetUserRoles PRIMARY KEY (UserId,RoleId),
     foreign key(UserId)
-        references AspNetUsers(Id),
+    references AspNetUsers(Id),
     foreign key(RoleId)
-        references AspNetRoles(Id)
+    references AspNetRoles(Id)
+    );
+
+create table Obstacle
+(
+    ObstacleID      varchar(300)  not null
+        primary key,
+    Heightmeter     int           not null,
+    GeometryGeoJson varchar(5000) null,
+    Name            varchar(100)  null,
+    Description     varchar(1000) null,
+    Illuminated     int default 0 not null,
+    Type            int           not null,
+    Status          int default 0 not null,
+    Marking         int default 0 not null,
+    CreationTime    datetime      null,
+    UpdatedTime     datetime      null,
+    UserId          varchar(255)  not null,
+    constraint ObstacleIlluminated_fk
+        foreign key (Illuminated) references Illuminated (Illuminated),
+    constraint ObstacleMarking_fk
+        foreign key (Marking) references Marking (Marking),
+    constraint ObstacleStatus_fk
+        foreign key (Status) references Status (Status),
+    constraint ObstacleType_fk
+        foreign key (Type) references ObstacleType (Type),
+    constraint Obstacle_UserId_fk
+        foreign key (UserId) references AspNetUserRoles (UserId)
 );
 
 insert into AspNetRoles(id, Name, NormalizedName) values('Administrator', 'Administrator', 'Administrator');
@@ -185,8 +180,8 @@ VALUES ('658bd502-a855-4a06-b0bd-a48e874e1803', 'pilot@pilot.com', 'PILOT@PILOT.
         0);
 
 INSERT INTO AspNetUsers (Id, UserName, NormalizedUserName, Email, NormalizedEmail, EmailConfirmed, PasswordHash,
-                             SecurityStamp, ConcurrencyStamp, PhoneNumber, PhoneNumberConfirmed, TwoFactorEnabled,
-                             LockoutEnd, LockoutEnabled, AccessFailedCount)
+                         SecurityStamp, ConcurrencyStamp, PhoneNumber, PhoneNumberConfirmed, TwoFactorEnabled,
+                         LockoutEnd, LockoutEnabled, AccessFailedCount)
 VALUES ('51d67027-dc61-4b05-b33b-d02481e9cb2b', 'registrar@registrar.com', 'REGISTRAR@REGISTRAR.COM', 'registrar@registrar.com',
         'REGISTRAR@REGISTRAR.COM', true,
         'AQAAAAIAAYagAAAAEDBuir2sH0Q4eCYdyWluFA+4ZiMaW72/Wcu0J28hu96bdJ4q160KQy5BygfW0K3L9g==',

--- a/db.sql
+++ b/db.sql
@@ -26,38 +26,6 @@ create table Status
     StatusName varchar(100) null
 );
 
-create table Obstacle
-(
-    ObstacleID      varchar(300)  not null
-        primary key,
-    Heightmeter     int           not null,
-    GeometryGeoJson varchar(5000) null,
-    Name            varchar(100)  null,
-    Description     varchar(1000) null,
-    Illuminated     int default 0 not null,
-    Type            int           not null,
-    Status          int default 0 not null,
-    Marking         int default 0 not null,
-    CreationTime    datetime      null,
-    UpdatedTime     datetime      null,
-    UserId          varchar(255)  not null,
-    constraint ObstacleIlluminated_fk
-        foreign key (Illuminated) references Illuminated (Illuminated),
-    constraint ObstacleMarking_fk
-        foreign key (Marking) references Marking (Marking),
-    constraint ObstacleStatus_fk
-        foreign key (Status) references Status (Status),
-    constraint ObstacleType_fk
-        foreign key (Type) references ObstacleType (Type),
-    constraint Obstacle_UserId_fk
-        foreign key (UserId) references AspNetUserRoles (UserId)
-);
-
-
-
-
-
-
 create table test
 (
     test_column int null
@@ -163,6 +131,33 @@ create table if not EXISTS AspNetUserRoles
         references AspNetUsers(Id),
     foreign key(RoleId)
         references AspNetRoles(Id)
+);
+
+create table Obstacle
+(
+    ObstacleID      varchar(300)  not null
+        primary key,
+    Heightmeter     int           not null,
+    GeometryGeoJson varchar(5000) null,
+    Name            varchar(100)  null,
+    Description     varchar(1000) null,
+    Illuminated     int default 0 not null,
+    Type            int           not null,
+    Status          int default 0 not null,
+    Marking         int default 0 not null,
+    CreationTime    datetime      null,
+    UpdatedTime     datetime      null,
+    UserId          varchar(255)  not null,
+    constraint ObstacleIlluminated_fk
+        foreign key (Illuminated) references Illuminated (Illuminated),
+    constraint ObstacleMarking_fk
+        foreign key (Marking) references Marking (Marking),
+    constraint ObstacleStatus_fk
+        foreign key (Status) references Status (Status),
+    constraint ObstacleType_fk
+        foreign key (Type) references ObstacleType (Type),
+    constraint Obstacle_UserId_fk
+        foreign key (UserId) references AspNetUserRoles (UserId)
 );
 
 insert into AspNetRoles(id, Name, NormalizedName) values('Administrator', 'Administrator', 'Administrator');


### PR DESCRIPTION
This pull request reorganizes the creation of the `Obstacle` table in both `db.sql` and `SQL-script-history/Version_9-12.11.25.sql`. The main change is moving the definition of the `Obstacle` table to a later point in the SQL scripts, after the definition of related tables and foreign key dependencies. There are no changes to the schema of the `Obstacle` table itself.

**Database schema organization:**

* Moved the creation of the `Obstacle` table in both `db.sql` and `SQL-script-history/Version_9-12.11.25.sql` to after the creation of the `AspNetUserRoles` table, ensuring that all referenced tables and foreign keys exist before defining `Obstacle`. [[1]](diffhunk://#diff-2fe243b4264993cf43bbbdc63e51e1b320c70fe37ce03eecd758bf8de401e420L29-L60) [[2]](diffhunk://#diff-2fe243b4264993cf43bbbdc63e51e1b320c70fe37ce03eecd758bf8de401e420R136-R162) [[3]](diffhunk://#diff-9b9926e00087702f12ad2c00e929a6b37f61ea2f5ccd9414d10e7386384d066dL29-L60) [[4]](diffhunk://#diff-9b9926e00087702f12ad2c00e929a6b37f61ea2f5ccd9414d10e7386384d066dR136-R162)